### PR TITLE
Add modal cleanup manager

### DIFF
--- a/src/core/GameEngine.js
+++ b/src/core/GameEngine.js
@@ -6,6 +6,7 @@ import { politicalEvents } from './PoliticalEvents';
 import { winConditions } from './WinConditions';
 import { gameReset } from './GameReset';
 import { aiOpposition } from './AIOpposition';
+import { modalManager } from '../ui/components/ModalManager';
 
 /**
  * GameEngine - Core game loop and state management for SP_Sim
@@ -344,6 +345,9 @@ export class GameEngine {
   resetGame(newGameState) {
     // Stop current game
     this.stop();
+
+    // Ensure any open modals are cleared
+    modalManager.cleanup();
 
     // Reset achievements
     this.winConditions.resetAchievements();

--- a/src/ui/components/ModalManager.js
+++ b/src/ui/components/ModalManager.js
@@ -1,0 +1,45 @@
+export class ModalManager {
+  constructor(eventSystem) {
+    this.eventSystem = eventSystem;
+    this.modals = new Set();
+
+    // Track modals on show/hide
+    this.eventSystem.on('modal:show', (event) => {
+      if (event.data && event.data.modal) {
+        this.modals.add(event.data.modal);
+      }
+    });
+
+    this.eventSystem.on('modal:hide', (event) => {
+      if (event.data && event.data.modal) {
+        this.modals.delete(event.data.modal);
+      }
+    });
+
+    // Cleanup on game start or reset events
+    this.eventSystem.on('game:reset', () => {
+      this.cleanup();
+    });
+    this.eventSystem.on('game:start', () => {
+      this.cleanup();
+    });
+  }
+
+  /**
+   * Destroy or hide all tracked modals
+   */
+  cleanup() {
+    this.modals.forEach((modal) => {
+      if (typeof modal.destroy === 'function') {
+        modal.destroy();
+      } else if (typeof modal.hide === 'function') {
+        modal.hide();
+      }
+    });
+    this.modals.clear();
+  }
+}
+
+// Export singleton instance using global event system
+import { eventSystem } from '../../core/EventSystem';
+export const modalManager = new ModalManager(eventSystem);

--- a/tests/unit/GameEngine.test.js
+++ b/tests/unit/GameEngine.test.js
@@ -171,4 +171,18 @@ describe('GameEngine', () => {
     expect(result.e).toEqual([1, 2, 3]); // unchanged array
     expect(result.g).toBe(5); // added
   });
+
+  test('resetGame should cleanup modals', () => {
+    const modal = new (require('../../src/ui/components/Modal').Modal)();
+    modal.show();
+    const { modalManager } = require('../../src/ui/components/ModalManager');
+    const spy = jest.spyOn(modalManager, 'cleanup');
+
+    gameEngine.resetGame(gameEngine.createInitialGameState());
+
+    expect(spy).toHaveBeenCalled();
+    expect(modalManager.modals.size).toBe(0);
+
+    spy.mockRestore();
+  });
 });

--- a/tests/unit/ModalManager.test.js
+++ b/tests/unit/ModalManager.test.js
@@ -1,0 +1,41 @@
+import { modalManager } from '../../src/ui/components/ModalManager';
+import { Modal } from '../../src/ui/components/Modal';
+import { eventSystem, EVENTS } from '../../src/core/EventSystem';
+
+describe('ModalManager', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    modalManager.cleanup();
+  });
+
+  afterEach(() => {
+    modalManager.cleanup();
+    document.body.innerHTML = '';
+  });
+
+  test('should track modals on show and hide', () => {
+    const modal = new Modal();
+    expect(modalManager.modals.size).toBe(0);
+
+    modal.show();
+    expect(modalManager.modals.size).toBe(1);
+
+    modal.hide();
+    expect(modalManager.modals.size).toBe(0);
+  });
+
+  test('should cleanup modals on game start', () => {
+    const modal1 = new Modal();
+    const modal2 = new Modal();
+    modal1.show();
+    modal2.show();
+
+    expect(modalManager.modals.size).toBe(2);
+
+    eventSystem.emit(EVENTS.GAME_START);
+
+    expect(modalManager.modals.size).toBe(0);
+    expect(modal1.isOpen).toBe(false);
+    expect(modal2.isOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add `ModalManager` for tracking modals
- clear open modals when the game starts or resets
- invoke cleanup in `GameEngine.resetGame`
- test modal manager and verify cleanup in GameEngine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687526d627208333a17da3f093ccb2d3